### PR TITLE
Patch for allowing /dev/... for -t target device

### DIFF
--- a/sbin/ocs-onthefly
+++ b/sbin/ocs-onthefly
@@ -2093,6 +2093,9 @@ parse_ocs_onthefly_cmd_options() {
               if [ -z "$(echo $1 |grep ^-.)" ]; then
                 # skip the -xx option, in case 
                 tgt_dev=$1
+                if [[ "$tgt_dev" =~ ^\/dev\/ ]]; then
+                    tgt_dev=${tgt_dev:5}
+                fi
                 shift
               fi
               [ -z "$tgt_dev" ] && USAGE && exit 1


### PR DESCRIPTION
I'm sure there are others than me who also type /dev/ automatically when interacting with devices and to help those people I created this simple but very useful patch. I'm sure there are better ways to do it and if one is figured out feel free to reject this patch. Also there might be similiar problems elsewhere in the clonezilla and I fixed this one because it's the one I encountered, someone with more knowledge should find the others if they feel it's worth the effort.

tl;dr
Allow for -t /dev/sda instead of just -t sda when running ocs-onthefly.