### PR TITLE
update-efi-nvram-boot-entry: handle eMMC disks

### DIFF
--- a/sbin/update-efi-nvram-boot-entry
+++ b/sbin/update-efi-nvram-boot-entry
@@ -389,7 +389,14 @@ if [ ! -d "/sys/firmware/efi/efivars/" ]; then
 fi
 esp_no="$(get_efi_system_part ${disk_})"
 if [ -n "$esp_no" ]; then
-  efi_system_part="${disk_}${esp_no}"
+  case "${disk_}" in
+    *mmcblk*)
+      efi_system_part="${disk_}p${esp_no}"
+      ;;
+    *)
+      efi_system_part="${disk_}${esp_no}"
+      ;;
+  esac
   echo "EFI system partition: ${efi_system_part}"
 else
   [ "$BOOTUP" = "color" ] && $SETCOLOR_WARNING

--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -1746,11 +1746,18 @@ get_swap_partition_parted_format() {
 	 return 1
        fi
        # swdisk is like sda
-       swdisk="$(LC_ALL=C grep -E "^Disk /dev/[sh]d[a-z]+" $partition_table | awk -F " " '{print $2}' | sed -r -e "s|^[[:space:]]*||g" -e "s|/dev/||g" -e "s|:||g")"
+       swdisk="$(LC_ALL=C grep -E "^Disk /dev/([sh]d[a-z]+|mmcblk[0-9])" $partition_table | awk -F " " '{print $2}' | sed -r -e "s|^[[:space:]]*||g" -e "s|/dev/||g" -e "s|:||g")"
 
        for i in $swparts; do
          # sda + 2 -> sda2
-         known_parts="$known_parts ${swdisk}${i}"
+         case "$swdisk" in
+           mmcblk*)
+             known_parts="$known_parts ${swdisk}p${i}"
+	     ;;
+	   *)
+             known_parts="$known_parts ${swdisk}${i}"
+	     ;;
+	   esac
        done
     fi
     # The return known_parts is like: sda1 sda2


### PR DESCRIPTION
Partition device of an eMMC disk needs a p before the number.

Refer https://github.com/stevenshiau/clonezilla/issues/14 for details.