### PR TITLE
Fix missing background image with Grub2

### DIFF
--- a/sbin/ocs-live-boot-menu
+++ b/sbin/ocs-live-boot-menu
@@ -566,16 +566,23 @@ cat <<-BOOT_MENU_END > $output_file
 #
 set pref=/EFI/boot
 set default="0"
+
+# Load graphics (only corresponding ones will be found)
+# (U)EFI
+insmod efi_gop
+insmod efi_uga
+# legacy BIOS
+insmod vbe
+
 if loadfont \$pref/unicode.pf2; then
   set gfxmode=auto
-  insmod efi_gop
-  insmod efi_uga
   insmod gfxterm
   terminal_output gfxterm
 fi
 set timeout="$timeout_sec"
 set hidden_timeout_quiet=false
 
+insmod png
 if background_image \$pref/$bg_img; then
   set color_normal=black/black
   set color_highlight=magenta/black


### PR DESCRIPTION
The background image is not shown without this. (If a grub.cfg file which refers to this grub.cfg file does not do something similar before the referral.) At least not with legacy BIOS.

This basically adds following:
* `insmod vbe` (needed for legacy BIOS graphics; should not interfere with (U)EFI, as `vbe.mod` should not exist there - respective "not found" error line will very briefly flash by, just like in case of `efi_gop.mod` and `efi_uga.mod` on legacy BIOS)

* `insmod png` (needed generally, for display of the PNG background image)

This change has been tested by patching the `/EFI/boot/grub.cfg` file respectively. With clonezilla-live-2.4.5-7-amd64, Grub2 version 2.02~beta2-9ubuntu1.6 on legacy BIOS.