### PR TITLE
Add bc as a dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: http://clonezilla.org/
 
 Package: clonezilla
 Architecture: all
-Depends: ${misc:Depends}, perl, bash (>= 4.0.0), wget, drbl (>= 2.27.3), partclone (>= 0.3.11), partimage (>= 0.6.7), ntfsprogs (>= 1.13.1) | ntfs-3g (>= 1:2012.1.15AR.1), udpcast, isolinux (>= 6.0)
+Depends: ${misc:Depends}, perl, bash (>= 4.0.0), wget, drbl (>= 2.27.3), partclone (>= 0.3.11), partimage (>= 0.6.7), ntfsprogs (>= 1.13.1) | ntfs-3g (>= 1:2012.1.15AR.1), udpcast, isolinux (>= 6.0), bc
 Recommends:
 Suggests:
 Description: Partition/disk cloning/imaging tool


### PR DESCRIPTION
We've been installing the clonezilla script on Ubuntu 16.04, and we run into an issue where `bc` is not found unless we explicitly install it.

https://github.com/ec2-software/ovirt-backup#clonezilla

Note: I have not tried to build a debian package with this change.