### PR TITLE
It should not check source device busy in network mode

### DIFF
--- a/sbin/ocs-onthefly
+++ b/sbin/ocs-onthefly
@@ -2838,10 +2838,11 @@ fi
 # Check if any source partition is busy or not.
 # $src_pt_info format:
 # "/dev/$part $filesystem $pt_size" 
-while read ipart part_fs size; do
-  check_if_dev_busy $ipart
-done < $src_pt_info
-
+if [ "$mode" != "network" ]; then
+  while read ipart part_fs size; do
+    check_if_dev_busy $ipart
+  done < $src_pt_info
+fi
 # Run fsck on the source partition
 do_fsck_in_source_dev_if_assigned
 


### PR DESCRIPTION
The ocs-onthefly fails when I cloned an entire disk from a network. As I traced the ocs-onthefly, it failed when it was checking if the source devices are busy. This action should be only done on the source system but not the target.