### PR TITLE
RAID1 not available to select in savedisk or restoredisk

### DIFF
--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -10885,7 +10885,7 @@ check_if_disk_busy() {
     if [ -n "$(grep -Ew -- "^${src_dev_}([0-9]*|(p[0-9]+))" /proc/swaps)" ]; then
       # Is busy (swap on)
       rc_d=0
-    elif [ -n "$(LC_ALL=C lsblk -npr -o name,type ${src_dev_} | awk -F" " '$2 ~ IGNORECASE=1;/lvm/ {print $1}')" ]; then
+    elif [ -n "$(LC_ALL=C lsblk -npr -o name,type ${src_dev_} | awk 'BEGIN { IGNORECASE=1;-F" " }; $2 ~ /PAR/ {print $1}')" ]; then
       # Is busy (LV active)
       rc_d=0
     else
@@ -12132,7 +12132,7 @@ is_partition() {
   local RE2='i2o/hd[a-z]+[0-9]+'
   local RE3='cciss/c[0-9]d[0-9]p[0-9]+'
   local RE4='mmcblk[0-9]+p+[0-9]+'
-  local RE5='md[0-9]+p?[0-9]*'
+  local RE5='md[0-9]+p+[0-9]*'
   local RE6='rd/c[0-9]d[0-9]p[0-9]+'
   local RE7='ida/c[0-9]d[0-9]p[0-9]+'
   local RE8='nvme[0-9]+n[0-9]+p+[0-9]+'

--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -10885,7 +10885,7 @@ check_if_disk_busy() {
     if [ -n "$(grep -Ew -- "^${src_dev_}([0-9]*|(p[0-9]+))" /proc/swaps)" ]; then
       # Is busy (swap on)
       rc_d=0
-    elif [ -n "$(LC_ALL=C lsblk -npr -o name,type ${src_dev_} | awk 'BEGIN { IGNORECASE=1;-F" " }; $2 ~ /PAR/ {print $1}')" ]; then
+    elif [ -n "$(LC_ALL=C lsblk -npr -o name,type ${src_dev_} | awk 'BEGIN { IGNORECASE=1;-F" " }; $2 ~ /lvm/ {print $1}')" ]; then
       # Is busy (LV active)
       rc_d=0
     else


### PR DESCRIPTION
Hi Steven. Further to a recent discussion on Sourceforge, these fixes allows RAID1 to be seen in the disk selection dialogs again (md126). You have said that you made the change to have RAID detected as a partition only so I'm not sure how you feel about this.
The second change was needed as /dev/md126 was being flagged as busy when trying to restore to it. This was a very unusual situation caused by IGNORECASE=1 where it was printing out the line with raid1 every time regardless of a match or not.