### PR TITLE
typo #124

### DIFF
--- a/sbin/ocs-ezio-leecher
+++ b/sbin/ocs-ezio-leecher
@@ -97,10 +97,10 @@ sleep 1
 cols="$(LC_ALL=C tput cols)"
 lines="$(LC_ALL=C tput lines)"
 if [ "$cols" -lt 80 -o "$lines" -lt 24 ]; then
-  echo "Termianl is $cols x $lines. Use Ezio simple output mode..."
+  echo "Terminal is $cols x $lines. Use Ezio simple output mode..."
   ezio_cli.py
 else
-  echo "Termianl is $cols x $lines. Use Ezio TUI mode..."
+  echo "Terminal is $cols x $lines. Use Ezio TUI mode..."
   ezio_ui.py
 fi
 


### PR DESCRIPTION
replaced 'termianl' with 'terminal'