### PR TITLE
init ci add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch: null
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        id: stale
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+          days-before-stale: 30
+          days-before-close: 5
+          exempt-issue-labels: 'blocked,must,should,keep'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Hi there 

I hope contributions are welcome in this repository.

This pull request aims to start adding basic CI/CD workflows—starting with a stale issue handler. 
The purpose of this initial workflow is to help keep the issue board clean and manageable for both maintainers and contributors.

The workflow automatically marks issues as stale after 30 days of inactivity and closes them 5 days later if no further activity occurs. This can help reduce clutter and make it easier to focus on active issues.

Best