### PR TITLE
add test scripts for debian/tests

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,3 @@
+Tests: run-smoke-check
+Depends: @, shunit2, coreutils, locales, jq, html2text, console-setup, udev
+Restrictions: allow-stderr, superficial, needs-root

--- a/debian/tests/run-smoke-check
+++ b/debian/tests/run-smoke-check
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+
+set -e
+
+#test_clonezilla_ocs_sr_smoke_test(){
+#  echo "ocs-sr"
+#  ocs-sr --help
+#  retur 0
+#}
+#
+#test_clonezilla_ocs_onthefly_smoke_test(){
+#  echo "ocs-onthefly"
+#  ocs-onthefly --help
+#  retur 0
+#}
+
+test_ocs_blk_info(){
+  echo "ocs blk info test"
+  /usr/bin/ocs-blk-dev-info testOutputFile
+}
+
+test_ocs_scan_disk(){
+  echo "ocs scan disk test"
+  /usr/bin/ocs-scan-disk
+}
+
+#test_ocs_console_font_size(){
+#  echo "ocs console font size test"
+#  /usr/sbin/ocs-console-font-size
+#}
+
+test_basic_function(){
+  echo "basic function test"
+  # Load DRBL setting and functions
+  DRBL_SCRIPT_PATH="${DRBL_SCRIPT_PATH:-/usr/share/drbl}"
+  . $DRBL_SCRIPT_PATH/sbin/drbl-conf-functions
+  . /etc/drbl/drbl-ocs.conf
+  . $DRBL_SCRIPT_PATH/sbin/ocs-functions
+  gen_proc_partitions_map_file
+  disk_proc="$(get_disk_list $partition_table)"
+}
+
+. shunit2
+


### PR DESCRIPTION
add test scripts for debian/tests

get smoke test result while running test `sudo autopkgtest --apt-upgrade  -s clonezilla_5.12.10-1_source.changes  -- schroot unstable-amd64-sbuild`

```
autopkgtest [09:35:15]: test run-smoke-check: [-----------------------
test_ocs_blk_info
ocs blk info test
Running in chroot, ignoring request.
test_ocs_scan_disk
ocs scan disk test
2025/09/25 01:35:16
You can insert storage device into this machine now if you want to use that, then wait for it to be detected.
Scanning devices... Available disk(s) on this machine:
===================================
NAME     TYPE  SIZE    MODEL           SERIAL          ID_PATH
Unknown device "/dev/nvme0n1": No such device
nvme0n1  disk  931.5G  .. .. .  ....    N/A
Unknown device "/dev/nvme1n1": No such device
nvme1n1  disk  931.5G  .. .. ..  ....    N/A
Unknown device "/dev/sda": No such device
sda      disk  1.8T    .... .... N/A
Unknown device "/dev/sdb": No such device
sdb      disk  7.3T    ....-. ....-.. N/A
===================================
Updates periodically.
Press Ctrl-C to exit this window.
test_basic_function
basic function test

Ran 3 tests.

OK
autopkgtest [09:35:18]: test run-smoke-check: -----------------------]
autopkgtest [09:35:18]: test run-smoke-check:  - - - - - - - - - - results - - - - - - - - - -
run-smoke-check      PASS (superficial)
autopkgtest [09:35:18]: @@@@@@@@@@@@@@@@@@@@ summary
run-smoke-check      PASS (superficial)
```