### PR TITLE
Bitlocker partitions can be decrypted before backups!

### DIFF
--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -4914,13 +4914,13 @@ ask_to_decrypt_bitlocker_partition() {
     #this are the a global settings
     BITLOCKER_DECRYPTED_PARTITIONS_PATH="/tmp/bitlocker_decrypted_partitions"
 
-    msg_bitlocker_disclaimer_00="The followng partition is encrypted with BitLocker:"
+    msg_bitlocker_disclaimer_00="The following partition is encrypted with BitLocker:"
     msg_bitlocker_disclaimer_01="We have two options now:"
     msg_bitlocker_disclaimer_02="- Backup it as is (encrypted, takes longer and compression will have no effect)"
     msg_bitlocker_disclaimer_03="- Backup the decrypted data (requires encryption key/password, is quicker, compression will work as usual)"
 
     msg_bitlocker_disclaimer_04="If you backup the decrypted data, whenever you restore it, you will need to use Windows to encrypt it again on the target machine."
-    msg_bitlocker_disclaimer_05="The encrypted partition in this machine will keep being encrypted regardless of which choice you pick."
+    msg_bitlocker_disclaimer_05="The encrypted partition in this machine will stay encrypted regardless of which choice you pick."
 
     msg_bitlocker_disclaimer_06="This should be used only with NTFS. Do not use with Resilient File System (ReFS). It should not work."
     msg_bitlocker_disclaimer_07="This is unrelated to the clonezilla setting of encrypting the backup. If that option is enabled, your backup will be encrypted by clonezilla."


### PR DESCRIPTION
closes https://github.com/stevenshiau/clonezilla/issues/84

This allows Clonezilla to ask for the password and decrypt BitLocker partitions, so it does not have to backup the free space and compression will actually work.

The passwords of all bitlocker partitions are requested at once, after the command to directly do the backup is provided, but before the confirmation itself.

The advantages of this approach are:

- we don't save the bitlocker password anywhere
- the command to do backups (for example `/usr/sbin/ocs-sr -q2 -c -j2 -z9p -i 0 -sfsck -scs -senc -p choose savedisk "2025-10-20-10-img" nvme0n1`) does not change

Also, since all bitlocker passwords are asked at once, after the backups start they won't pause asking for extra passwords.

Other remarks:

* I am not using `$DIA` / ` whiptail` to ask for the password because I don't want it stored in a temporary file
* I am showing the password instead of showing asterisks, because the Bitlocker recovery key is a pain to type right, let alone without seeing it.
* I have no clue how localizations work in clonezilla, so I left very obvious the msg variables that should go to the right place. Please help me with that.
* I tested with Windows 11 and NTFS and it worked. I can't test with ResilientFS. I don't think that's a problem. I do inform the user about that


<img width="1243" height="1008" alt="image" src="https://github.com/user-attachments/assets/e98b1190-7cc2-4b73-bdb9-fed41fcfdea3" />

