### PR TITLE
BitLocker asks the password again if it is wrong

### DIFF
--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -4953,7 +4953,9 @@ ask_to_decrypt_bitlocker_partition() {
     esac
 
     mkdir -p "$target_path"
+    echo  "Device: $fancy_dev_name"
     read -s -p "$msg_bitlocker_request_password " bitlocker_password
+    echo
     echo
     echo "$msg_bitlocker_use_recovery_password"
     dislocker /dev/${device} "$target_path" -p${bitlocker_password}


### PR DESCRIPTION
With this fix, whenever saving a partition, whenever one types the wrong bitlocker password, it is asked again.
Also, it will now show what partition we are asking the bitlocker password for (useful with multiple bitlocker partitions)

Two items one should be aware:

a) as of now, if one does not know the bit locker password, one can't go back. I am not sure if this is a bug or a feature.
b) I am still not sure if the password not being shown is the right thing to do, since my test VM Key is 56 chars long ( 226963-543147-075647-288244-881264-497937-568018-485892 )
