### PR TITLE
BitLocker partitions now work on the clone_server (ocs-onthefly)

### DIFF
--- a/sbin/ocs-onthefly
+++ b/sbin/ocs-onthefly
@@ -307,7 +307,13 @@ clone_over_net() {
            [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
         else
            check_if_dev_busy $src_dev
-           onthefly_feed_partition_or_lv_in_server $part_fs $src_dev
+           local bitlocker_partition_unlocked="${bitlocker_decr_part_dir}/${src_dev}/dislocker-file"
+           if [[ -f "$bitlocker_partition_unlocked" ]]
+           then
+              onthefly_feed_partition_or_lv_in_server $part_fs ..${bitlocker_partition_unlocked}
+           else
+              onthefly_feed_partition_or_lv_in_server $part_fs $src_dev
+           fi
         fi
         example_target="sda1, sda2 or..."
         ;;
@@ -330,7 +336,13 @@ clone_over_net() {
              echo "Skip feeding partition $spart since it is $part_fs..." | tee --append $OCS_LOGFILE
           else
              check_if_dev_busy $spart
-             onthefly_feed_partition_or_lv_in_server $part_fs $spart
+             local bitlocker_partition_unlocked="${bitlocker_decr_part_dir}/${spart}/dislocker-file"
+             if [[ -f "$bitlocker_partition_unlocked" ]]
+             then
+                onthefly_feed_partition_or_lv_in_server $part_fs ..${bitlocker_partition_unlocked}
+             else
+                onthefly_feed_partition_or_lv_in_server $part_fs $spart
+             fi
           fi
         done
         exec 5<&-

--- a/scripts/sbin/ocs-functions
+++ b/scripts/sbin/ocs-functions
@@ -1723,6 +1723,7 @@ save_part_by_dd() {
 #
 image_save() {
   local source_dev="$(format_dev_name_with_leading_dev $1)" # e.g., /dev/sda1
+  local source_dev_pre_bitlocker="$source_dev"
   local tgt_dir="$2"
   local tgt_file="$3"
   local image_name_
@@ -1786,7 +1787,7 @@ image_save() {
   else
     part_fs_shown="$part_fs"
   fi
-  echo "$source_dev $part_fs $part_size" >> "$tgt_dir/dev-fs.list"
+  echo "$source_dev_pre_bitlocker $part_fs $part_size" >> "$tgt_dir/dev-fs.list"
 
   # do_fs_save is a global variable
   if [ "$do_fs_save" = "yes" ]; then
@@ -4163,7 +4164,8 @@ task_postprocessing() {
       ;;
   esac
 
-  unmount_dislocker_mount_point_if_necessary
+  echo "We are not unmouting the bitlocker partitions, for if we do we break the clone_server (ocs-onthefly)"
+  # unmount_dislocker_mount_point_if_necessary
 
   # Try to put Clonezilla related log files to Clonezilla live USB drive
   if [ "$put_log_usb" = "yes" ]; then


### PR DESCRIPTION
We now support bitlocker when cloning machines directly, over the network.


Also, we do not put the unencrypted dislocker bitlocker partition into `dev-fs.list` anymore, which means we, just like before the first bitlocker pull request.

the philosophy is the same, the source machine sends the data as if it was a non encrypted ntfs partition.
the target machine is not even aware of the existence of bitlocker.

which means old versions of clonezilla should restore backups as they've always did