### PR TITLE
cnvt-ocsiso-qcow2 version: 0.4.1

### DIFF
--- a/sbin/cnvt-ocsiso-qcow2
+++ b/sbin/cnvt-ocsiso-qcow2
@@ -4,7 +4,7 @@
 # Program to convert Clonezilla live iso to qcow2 virtual disk file.
 set -e
 
-VERSION="0.2.3"
+VERSION="0.4.1"
 
 # Colors for diff and output
 RED='\033[0;31m'
@@ -14,51 +14,64 @@ NC='\033[0m' # No Color
 
 usage() {
     cat <<EOF
-Usage: $(basename "$0") v${VERSION} -i <input.iso> -o <output.qcow2> [OPTIONS]
+Usage: $(basename "$0") v${VERSION} -i <input.iso> [OPTIONS]
 
-Convert a Clonezilla Live ISO into a bootable virtual hard disk (qcow2).
-Disk size is calculated automatically from the ISO content.
+Convert a Clonezilla Live ISO into a bootable virtual disk (qcow2/iso).
+If no packaging mode is explicitly selected, VHD mode is used by default.
+Both VHD and ISO modes can be enabled simultaneously.
 
 Options:
   -i <input.iso>          Path to the input Clonezilla Live ISO image (required)
-  -o <output.qcow2>       Path of the output qcow2 disk image (required)
+  --prefix <prefix>       Path/Name prefix of the output files (optional)
+                            Default: same as input ISO base name in current directory
   --redirect-boot-only    Generate a minimal boot-redirect disk:
                             - UEFI menu: "uEFI firmware setup" (default) + "Boot from Local Disk"
                             - BIOS menu: "Boot from Local Disk" (default)
                             Incompatible with -kb; -kb parameters are silently ignored.
+                            Output filenames are fixed: redirect-boot-vhd.qcow2 and/or
+                            redirect-boot-iso.qcow2 and redirect-boot-renew.iso.
   -kb <key=val> ...       Inject one or more kernel boot parameters into the Clonezilla
                           live boot menu entry. Multiple key=value pairs accepted.
+  --use-iso-mode, --use-ios-mode
+                          Enable ISO packaging mode:
+                            - Output qcow2: \${prefix}-iso.qcow2 (or redirect-boot-iso.qcow2 in redirect-only mode)
+                            - Output ISO:  \${prefix}-renwew.iso (or redirect-boot-renew.iso in redirect-only mode)
+  --use-vhd-mode          Enable VHD packaging mode (default if no mode selected):
+                            - Output qcow2: \${prefix}-vhd.qcow2 (or redirect-boot-vhd.qcow2 in redirect-only mode)
   -h, --help              Show this help message and exit
 
 Examples:
-  # Clonezilla Live VHD with custom kernel parameters:
+  # Convert to VHD qcow2 (default) with custom prefix and kernel parameters:
   $(basename "$0") \\
-      -i  clonezilla-live-3.3.3-8-amd64.iso \\
-      -o  ocs-live-3.3.3-8-amd64-4cloud.qcow2 \\
+      -i clonezilla-live-3.3.3-8-amd64.iso \\
+      --prefix my-clonezilla \\
       -kb locales=en_US.UTF-8 keyboard-layouts=us \\
           ocs_daemonon="ssh" ocs_prerun01="dhclient -v" \\
           toram=live,syslinux,EFI,boot,.disk,utils
 
-  # Minimal boot-redirect VHD (no Clonezilla live OS included):
+  # Convert to both ISO qcow2/iso and VHD qcow2 formats simultaneously:
   $(basename "$0") \\
-      --redirect-boot-only \\
       -i clonezilla-live-3.3.3-8-amd64.iso \\
-      -o redirect-boot.qcow2
+      --prefix my-clonezilla-dual \\
+      --use-iso-mode --use-vhd-mode
 EOF
     exit 1
 }
 
 # Parse arguments
 INPUT_ISO=""
-OUTPUT_QCOW2=""
-OUTPUT_ISO_FLAG=false
+PREFIX=""
 REDIRECT_BOOT_ONLY=false
+RUN_ISO_MODE=false
+RUN_VHD_MODE=false
 KB_PARAMS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -i) INPUT_ISO="$2"; shift 2 ;;
-        -o) OUTPUT_QCOW2="$2"; shift 2 ;;
+        --prefix) PREFIX="$2"; shift 2 ;;
+        --use-iso-mode|--use-ios-mode) RUN_ISO_MODE=true; shift ;;
+        --use-vhd-mode) RUN_VHD_MODE=true; shift ;;
         --redirect-boot-only) REDIRECT_BOOT_ONLY=true; shift ;;
         -h|--help) usage ;;
         -kb) 
@@ -77,7 +90,7 @@ if [[ "$REDIRECT_BOOT_ONLY" == "true" && ${#KB_PARAMS[@]} -gt 0 ]]; then
     KB_PARAMS=()
 fi
 
-if [[ -z "$INPUT_ISO" || -z "$OUTPUT_QCOW2" ]]; then
+if [[ -z "$INPUT_ISO" ]]; then
     usage
 fi
 
@@ -85,6 +98,23 @@ if [[ ! -f "$INPUT_ISO" ]]; then
     echo -e "${RED}Error: Input ISO '$INPUT_ISO' not found.${NC}"
     exit 1
 fi
+
+# Default packaging mode to VHD if neither is specified
+if [[ "$RUN_ISO_MODE" == "false" && "$RUN_VHD_MODE" == "false" ]]; then
+    RUN_VHD_MODE=true
+fi
+
+# Handle prefix and output directory
+if [[ -n "$PREFIX" ]]; then
+    OUTPUT_DIR=$(dirname "$PREFIX")
+    OUTPUT_BASE_PREFIX=$(basename "$PREFIX")
+else
+    INPUT_BASE=$(basename "$INPUT_ISO" .iso)
+    OUTPUT_DIR="."
+    OUTPUT_BASE_PREFIX="$INPUT_BASE"
+fi
+OUTPUT_DIR_ABS=$(realpath "$OUTPUT_DIR")
+mkdir -p "$OUTPUT_DIR_ABS"
 
 # Check dependencies
 dependencies=(xorriso 7z parted mkfs.vfat mcopy qemu-img numfmt)
@@ -143,6 +173,19 @@ modify_params() {
     echo "$line"
 }
 
+# Construct active modes description
+MODES_STR=""
+if [[ "$RUN_ISO_MODE" == "true" ]]; then
+    MODES_STR="--use-iso-mode"
+fi
+if [[ "$RUN_VHD_MODE" == "true" ]]; then
+    if [[ -n "$MODES_STR" ]]; then
+        MODES_STR="$MODES_STR, --use-vhd-mode"
+    else
+        MODES_STR="--use-vhd-mode"
+    fi
+fi
+
 # Files to modify
 FILES=("$EXTRACT_DIR/syslinux/syslinux.cfg" "$EXTRACT_DIR/syslinux/isolinux.cfg" "$EXTRACT_DIR/boot/grub/grub.cfg")
 
@@ -176,8 +219,8 @@ label info
   Converted by cnvt-ocsiso-qcow2 v${VERSION}
   Timestamp : $(date '+%Y-%m-%d %H:%M:%S %Z')
   Source ISO: $(basename "$INPUT_ISO")
-  Output    : $(basename "$OUTPUT_QCOW2")
-  Mode      : --redirect-boot-only
+  Prefix    : ${OUTPUT_BASE_PREFIX}
+  Modes     : --redirect-boot-only (${MODES_STR})
   endtext
 EOF
         elif [[ "$cfg" == *"grub.cfg" ]]; then
@@ -203,8 +246,8 @@ menuentry "Show Convert Info" --id show-convert-info {
   echo "  Converted by cnvt-ocsiso-qcow2 v${VERSION}"
   echo "  Timestamp : $(date '+%Y-%m-%d %H:%M:%S %Z')"
   echo "  Source ISO: $(basename "$INPUT_ISO")"
-  echo "  Output    : $(basename "$OUTPUT_QCOW2")"
-  echo "  Mode      : --redirect-boot-only"
+  echo "  Prefix    : ${OUTPUT_BASE_PREFIX}"
+  echo "  Modes     : --redirect-boot-only (${MODES_STR})"
   echo "----------------------------------------------"
   sleep --verbose --interruptible 30
 }
@@ -277,7 +320,8 @@ EOF
                 printf '  Converted by cnvt-ocsiso-qcow2 v%s\n' "${VERSION}"
                 printf '  Timestamp : %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')"
                 printf '  Source ISO: %s\n' "$(basename "$INPUT_ISO")"
-                printf '  Output    : %s\n' "$(basename "$OUTPUT_QCOW2")"
+                printf '  Prefix    : %s\n' "${OUTPUT_BASE_PREFIX}"
+                printf '  Modes     : %s\n' "${MODES_STR}"
                 printf '  -kb params: %s\n' "${KB_PARAMS[*]}"
                 printf '  endtext\n'
             } >> "$cfg"
@@ -335,6 +379,10 @@ EOF
             
             { print }
             ' "$cfg-bak" > "$cfg"
+            
+            # Escape double quotes for GRUB echo command to support params like ocs_prerun01="dhclient -v"
+            KB_PARAMS_ESCAPED=$(echo "${KB_PARAMS[*]}" | sed 's/"/\\"/g')
+
             # Append Show Convert Info menuentry
             {
                 printf '\nmenuentry "Show Convert Info" --id show-convert-info {\n'
@@ -342,8 +390,9 @@ EOF
                 printf '  echo "  Converted by cnvt-ocsiso-qcow2 v%s"\n' "${VERSION}"
                 printf '  echo "  Timestamp : %s"\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')"
                 printf '  echo "  Source ISO: %s"\n' "$(basename "$INPUT_ISO")"
-                printf '  echo "  Output    : %s"\n' "$(basename "$OUTPUT_QCOW2")"
-                printf '  echo "  -kb params: %s"\n' "${KB_PARAMS[*]}"
+                printf '  echo "  Prefix    : %s"\n' "${OUTPUT_BASE_PREFIX}"
+                printf '  echo "  Modes     : %s"\n' "${MODES_STR}"
+                printf '  echo "  -kb params: %s"\n' "${KB_PARAMS_ESCAPED}"
                 printf '  echo "----------------------------------------------"\n'
                 printf '  sleep --verbose --interruptible 30\n'
                 printf '}\n'
@@ -356,83 +405,7 @@ EOF
     diff --color=always -u "$cfg-bak" "$cfg" || true
 done
 
-# ----------------------------------------------------
-# 1. Auto-calculate required virtual disk size
-# ----------------------------------------------------
-echo -e "${BLUE}Calculating required disk size...${NC}"
-TOTAL_BYTES=$(du -sb "$EXTRACT_DIR" | cut -f1)
-# Add 15% headroom plus 50 MB (52428800 bytes) for partition alignment,
-# FAT metadata (FAT tables), and boot loader files
-VOLUME_SIZE_BYTES=$(( TOTAL_BYTES + (TOTAL_BYTES * 15 / 100) + 52428800 ))
-# Round up to the nearest 1 MiB boundary for partition alignment
-VOLUME_SIZE_BYTES=$(( (VOLUME_SIZE_BYTES + 1048575) / 1048576 * 1048576 ))
-
-echo -e "Required disk space: $(numfmt --to=iec --format="%.2f" $VOLUME_SIZE_BYTES)"
-
-# ----------------------------------------------------
-# 2. Create blank disk image and partition table
-# ----------------------------------------------------
-echo -e "${BLUE}Creating and partitioning raw disk image...${NC}"
-RAW_DISK="$WORKDIR/disk.raw"
-truncate -s "$VOLUME_SIZE_BYTES" "$RAW_DISK"
-
-# Create MBR (msdos) partition table with a FAT32 primary partition
-# starting at 1 MiB offset, and set the boot flag
-parted -s "$RAW_DISK" mklabel msdos
-parted -s "$RAW_DISK" mkpart primary fat32 1MiB 100%
-parted -s "$RAW_DISK" set 1 boot on
-
-# Retrieve the exact byte size of the created partition
-PART_SIZE_BYTES=$(parted -s "$RAW_DISK" unit b print | awk '$1 == "1" {print $4}' | tr -d 'B')
-if [[ -z "$PART_SIZE_BYTES" ]]; then
-    echo -e "${RED}Error: Failed to determine partition size from parted output.${NC}" >&2
-    exit 1
-fi
-
-# ----------------------------------------------------
-# 3. Create and format the partition image
-# ----------------------------------------------------
-echo -e "${BLUE}Formatting partition image...${NC}"
-PART_IMG="$WORKDIR/part.img"
-truncate -s "$PART_SIZE_BYTES" "$PART_IMG"
-mkfs.vfat -F 32 "$PART_IMG" >/dev/null
-
-# ----------------------------------------------------
-# 4. Install Syslinux boot sector into the partition image
-# ----------------------------------------------------
-echo -e "${BLUE}Installing Syslinux boot sector into partition image...${NC}"
-# Prefer the syslinux binary extracted from the Clonezilla ISO
-SYSLINUX_BIN=""
-if [[ "$(uname -m)" == "x86_64" ]]; then
-    SYSLINUX_BIN="$EXTRACT_DIR/utils/linux/x64/syslinux"
-else
-    SYSLINUX_BIN="$EXTRACT_DIR/utils/linux/x86/syslinux"
-fi
-
-if [[ -f "$SYSLINUX_BIN" ]]; then
-    chmod +x "$SYSLINUX_BIN"
-fi
-
-# Fall back to the system-installed syslinux if the extracted binary is not runnable on the host
-if [[ ! -x "$SYSLINUX_BIN" ]] || ! "$SYSLINUX_BIN" --version &>/dev/null; then
-    if command -v syslinux &>/dev/null; then
-        echo -e "Warning: Extracted syslinux not executable on host. Using system syslinux..."
-        SYSLINUX_BIN="syslinux"
-    else
-        echo -e "${RED}Error: Syslinux tool is not executable and system syslinux is missing.${NC}" >&2
-        exit 1
-    fi
-fi
-
-# Write ldlinux.sys into the root of the partition image
-"$SYSLINUX_BIN" -i "$PART_IMG"
-
-# ----------------------------------------------------
-# 5. Copy all files into the partition image
-# ----------------------------------------------------
-# ----------------------------------------------------
-# 5a. Write the repack command record: repack-command-qcow2.txt
-# ----------------------------------------------------
+# Save repack command record (shared across modes)
 echo -e "${BLUE}Saving repack command record...${NC}"
 REPACK_CMD_FILE="$WORKDIR/repack-command-qcow2.txt"
 cat > "$REPACK_CMD_FILE" <<EOF
@@ -442,53 +415,187 @@ cat > "$REPACK_CMD_FILE" <<EOF
 
 $(basename "$0") \\
     -i $(realpath "$INPUT_ISO") \\
-    -o $(realpath "$OUTPUT_QCOW2") \\
+    --prefix "$OUTPUT_DIR_ABS/$OUTPUT_BASE_PREFIX" \\
 EOF
 
 if [[ "$REDIRECT_BOOT_ONLY" == "true" ]]; then
-    echo "    --redirect-boot-only" >> "$REPACK_CMD_FILE"
+    echo "    --redirect-boot-only \\" >> "$REPACK_CMD_FILE"
 elif [[ ${#KB_PARAMS[@]} -gt 0 ]]; then
     {
         printf '    -kb'
         for p in "${KB_PARAMS[@]}"; do printf ' %s' "$p"; done
-        printf '\n'
+        printf ' \\\n'
     } >> "$REPACK_CMD_FILE"
 fi
 
-echo -e "${BLUE}Copying files to partition image using mtools...${NC}"
-export MTOOLS_SKIP_CHECK=1
-# Recursively copy all extracted files into the FAT partition image
-mcopy -i "$PART_IMG" -s "$EXTRACT_DIR"/* ::/
-# Write the repack command record to the partition root
-mcopy -i "$PART_IMG" "$REPACK_CMD_FILE" ::/repack-command-qcow2.txt
+if [[ "$RUN_ISO_MODE" == "true" ]]; then
+    echo "    --use-iso-mode \\" >> "$REPACK_CMD_FILE"
+fi
+if [[ "$RUN_VHD_MODE" == "true" ]]; then
+    echo "    --use-vhd-mode \\" >> "$REPACK_CMD_FILE"
+fi
+# Remove trailing backslash from the last line
+sed -i '$ s/ \\$//' "$REPACK_CMD_FILE"
 
-# ----------------------------------------------------
-# 6. Assemble disk: write MBR bootstrap code and partition data
-# ----------------------------------------------------
-echo -e "${BLUE}Assembling raw disk with bootloader and partition...${NC}"
-MBR_BIN="$EXTRACT_DIR/utils/mbr/mbr.bin"
-if [[ -f "$MBR_BIN" ]]; then
-    dd if="$MBR_BIN" of="$RAW_DISK" bs=440 count=1 conv=notrunc status=none
-else
-    echo -e "${RED}Warning: MBR bootstrap code $MBR_BIN not found. Boot may fail on BIOS.${NC}" >&2
+# -----------------------------------------------------------------------------
+# Execute Packaging Modes
+# -----------------------------------------------------------------------------
+
+if [[ "$RUN_ISO_MODE" == "true" ]]; then
+    # =========================================================================
+    # ISO packaging mode
+    # =========================================================================
+    # Copy repack command record to extracted directory root
+    cp "$REPACK_CMD_FILE" "$EXTRACT_DIR/repack-command-qcow2.txt"
+
+    # Rebuild ISO
+    echo -e "${BLUE}[ISO Mode] Rebuilding ISO...${NC}"
+    TMP_ISO="$WORKDIR/modified.iso"
+
+    # Retrieve original boot options using xorriso to maintain identical boot geometry
+    BOOT_OPTS=$(xorriso -indev "$INPUT_ISO" -report_el_torito as_mkisofs 2>/dev/null | grep -E '^--?[a-zA-Z0-9_-]+' | tr '\n' ' ')
+
+    if [[ -z "$BOOT_OPTS" ]]; then
+        echo -e "${RED}Error: Failed to extract boot layout from $INPUT_ISO${NC}" >&2
+        exit 1
+    fi
+
+    # Execute xorriso to rebuild ISO with modified files
+    eval "xorriso -as mkisofs $BOOT_OPTS -o \"$TMP_ISO\" \"$EXTRACT_DIR\" >/dev/null 2>&1"
+
+    # Convert rebuilt ISO to qcow2 format
+    if [[ "$REDIRECT_BOOT_ONLY" == "true" ]]; then
+        ISO_QCOW2="$OUTPUT_DIR_ABS/redirect-boot-iso.qcow2"
+        OUTPUT_ISO="$OUTPUT_DIR_ABS/redirect-boot-renew.iso"
+    else
+        ISO_QCOW2="$OUTPUT_DIR_ABS/${OUTPUT_BASE_PREFIX}-iso.qcow2"
+        OUTPUT_ISO="$OUTPUT_DIR_ABS/${OUTPUT_BASE_PREFIX}-renwew.iso"
+    fi
+
+    echo -e "${BLUE}[ISO Mode] Converting rebuilt ISO to qcow2 format: $(basename "$ISO_QCOW2")...${NC}"
+    qemu-img convert -f raw -O qcow2 "$TMP_ISO" "$ISO_QCOW2"
+
+    echo -e "${BLUE}[ISO Mode] Generating additional output: $(basename "$OUTPUT_ISO")...${NC}"
+    cp "$TMP_ISO" "$OUTPUT_ISO"
+    echo -e "${GREEN}[ISO Mode] Successfully generated: $ISO_QCOW2 & $OUTPUT_ISO${NC}"
 fi
 
-# Write the partition image at a 1 MiB offset into the raw disk
-dd if="$PART_IMG" of="$RAW_DISK" bs=1M seek=1 conv=notrunc status=none
+if [[ "$RUN_VHD_MODE" == "true" ]]; then
+    # =========================================================================
+    # VHD packaging mode (default)
+    # =========================================================================
+    # ----------------------------------------------------
+    # 1. Auto-calculate required virtual disk size
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Calculating required disk size...${NC}"
+    TOTAL_BYTES=$(du -sb "$EXTRACT_DIR" | cut -f1)
+    # Add 15% headroom plus 50 MB (52428800 bytes) for partition alignment,
+    # FAT metadata (FAT tables), and boot loader files
+    VOLUME_SIZE_BYTES=$(( TOTAL_BYTES + (TOTAL_BYTES * 15 / 100) + 52428800 ))
+    # Round up to the nearest 1 MiB boundary for partition alignment
+    VOLUME_SIZE_BYTES=$(( (VOLUME_SIZE_BYTES + 1048575) / 1048576 * 1048576 ))
 
-# ----------------------------------------------------
-# 7. Convert raw image to qcow2 format
-# ----------------------------------------------------
-echo -e "${BLUE}Converting raw image to qcow2 format...${NC}"
-# Ensure the output directory exists before writing
-OUTPUT_DIR=$(dirname "$OUTPUT_QCOW2")
-mkdir -p "$OUTPUT_DIR"
-OUTPUT_QCOW2_ABS=$(realpath "$OUTPUT_QCOW2")
+    echo -e "Required disk space: $(numfmt --to=iec --format="%.2f" $VOLUME_SIZE_BYTES)"
 
-qemu-img convert -f raw -O qcow2 "$RAW_DISK" "$OUTPUT_QCOW2_ABS"
+    # ----------------------------------------------------
+    # 2. Create blank disk image and partition table
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Creating and partitioning raw disk image...${NC}"
+    RAW_DISK="$WORKDIR/disk.raw"
+    truncate -s "$VOLUME_SIZE_BYTES" "$RAW_DISK"
+
+    # Create MBR (msdos) partition table with a FAT32 primary partition
+    # starting at 1 MiB offset, and set the boot flag
+    parted -s "$RAW_DISK" mklabel msdos
+    parted -s "$RAW_DISK" mkpart primary fat32 1MiB 100%
+    parted -s "$RAW_DISK" set 1 boot on
+
+    # Retrieve the exact byte size of the created partition
+    PART_SIZE_BYTES=$(parted -s "$RAW_DISK" unit b print | awk '$1 == "1" {print $4}' | tr -d 'B')
+    if [[ -z "$PART_SIZE_BYTES" ]]; then
+        echo -e "${RED}Error: Failed to determine partition size from parted output.${NC}" >&2
+        exit 1
+    fi
+
+    # ----------------------------------------------------
+    # 3. Create and format the partition image
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Formatting partition image...${NC}"
+    PART_IMG="$WORKDIR/part.img"
+    truncate -s "$PART_SIZE_BYTES" "$PART_IMG"
+    mkfs.vfat -F 32 "$PART_IMG" >/dev/null
+
+    # ----------------------------------------------------
+    # 4. Install Syslinux boot sector into the partition image
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Installing Syslinux boot sector into partition image...${NC}"
+    # Prefer the syslinux binary extracted from the Clonezilla ISO
+    SYSLINUX_BIN=""
+    if [[ "$(uname -m)" == "x86_64" ]]; then
+        SYSLINUX_BIN="$EXTRACT_DIR/utils/linux/x64/syslinux"
+    else
+        SYSLINUX_BIN="$EXTRACT_DIR/utils/linux/x86/syslinux"
+    fi
+
+    if [[ -f "$SYSLINUX_BIN" ]]; then
+        chmod +x "$SYSLINUX_BIN"
+    fi
+
+    # Fall back to the system-installed syslinux if the extracted binary is not runnable on the host
+    if [[ ! -x "$SYSLINUX_BIN" ]] || ! "$SYSLINUX_BIN" --version &>/dev/null; then
+        if command -v syslinux &>/dev/null; then
+            echo -e "Warning: Extracted syslinux not executable on host. Using system syslinux..."
+            SYSLINUX_BIN="syslinux"
+        else
+            echo -e "${RED}Error: Syslinux tool is not executable and system syslinux is missing.${NC}" >&2
+            exit 1
+        fi
+    fi
+
+    # Write ldlinux.sys into the root of the partition image
+    "$SYSLINUX_BIN" -i "$PART_IMG"
+
+    # ----------------------------------------------------
+    # 5. Copy all files into the partition image
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Copying files to partition image using mtools...${NC}"
+    export MTOOLS_SKIP_CHECK=1
+    # Recursively copy all extracted files (including hidden ones like .disk) into the FAT partition image
+    shopt -s dotglob
+    mcopy -o -i "$PART_IMG" -s "$EXTRACT_DIR"/* ::/
+    shopt -u dotglob
+    # Write the repack command record to the partition root
+    mcopy -o -i "$PART_IMG" "$REPACK_CMD_FILE" ::/repack-command-qcow2.txt
+
+    # ----------------------------------------------------
+    # 6. Assemble disk: write MBR bootstrap code and partition data
+    # ----------------------------------------------------
+    echo -e "${BLUE}[VHD Mode] Assembling raw disk with bootloader and partition...${NC}"
+    MBR_BIN="$EXTRACT_DIR/utils/mbr/mbr.bin"
+    if [[ -f "$MBR_BIN" ]]; then
+        dd if="$MBR_BIN" of="$RAW_DISK" bs=440 count=1 conv=notrunc status=none
+    else
+        echo -e "${RED}Warning: MBR bootstrap code $MBR_BIN not found. Boot may fail on BIOS.${NC}" >&2
+    fi
+
+    # Write the partition image at a 1 MiB offset into the raw disk
+    dd if="$PART_IMG" of="$RAW_DISK" bs=1M seek=1 conv=notrunc status=none
+
+    # ----------------------------------------------------
+    # 7. Convert raw image to qcow2 format
+    # ----------------------------------------------------
+    if [[ "$REDIRECT_BOOT_ONLY" == "true" ]]; then
+        VHD_QCOW2="$OUTPUT_DIR_ABS/redirect-boot-vhd.qcow2"
+    else
+        VHD_QCOW2="$OUTPUT_DIR_ABS/${OUTPUT_BASE_PREFIX}-vhd.qcow2"
+    fi
+    echo -e "${BLUE}[VHD Mode] Converting raw image to qcow2 format: $(basename "$VHD_QCOW2")...${NC}"
+    qemu-img convert -f raw -O qcow2 "$RAW_DISK" "$VHD_QCOW2"
+    echo -e "${GREEN}[VHD Mode] Successfully generated: $VHD_QCOW2${NC}"
+fi
 
 # ----------------------------------------------------
 # 8. Clean up working directory and finish
 # ----------------------------------------------------
 rm -rf "$WORKDIR"
-echo -e "${GREEN}Successfully generated bootable virtual hard disk at: $OUTPUT_QCOW2_ABS${NC}"
+echo -e "${GREEN}All tasks completed successfully!${NC}"


### PR DESCRIPTION
refactor cnvt-ocsiso-qcow2 with dual packaging, flexible prefixing, and boot fixes

1. Support Dual-Packaging Modes: Enable both `--use-vhd-mode` and `--use-iso-mode` to run simultaneously in a single execution, sharing extraction and configuration steps.
2. Deprecate `-o` in Favor of Optional `--prefix`: Replace the mandatory `-o` output flag with `--prefix`.
3. Fix Boot Kernel Panic & Refine Redirect Output Naming: Resolve a critical VHD boot kernel panic by enabling `dotglob` in `mcopy` to preserve hidden `.disk/` UUID metadata.