### PR TITLE
create-gparted-live: Add nvme-cli and arch-install-scripts

### DIFF
--- a/sbin/create-gparted-live
+++ b/sbin/create-gparted-live
@@ -37,13 +37,13 @@ discover lsscsi pciutils ifupdown dhcp*-client$ cryptsetup gpart \
 smartmontools vim-tiny gdisk fsarchiver mdadm sudo \
 hicolor-icon-theme netbase ssh pppoeconf ethtool whiptail lshw \
 open-iscsi tree cifs-utils nilfs-tools netsurf-gtk \
-ca-certificates scsitools blktool safecopy \
+ca-certificates scsitools nvme-cli blktool safecopy \
 net-tools iproute2 iw pcmanfm geany tcplay f2fs-tools \
 partclone partimage screen rsync iputils-ping telnet traceroute bc lsof \
 psmisc dnsutils wget ftp bzip2 xz-utils zip unzip w3m gsmartcontrol \
 gddrescue ddrescueview zerofree efibootmgr libpam-systemd polkitd pkexec \
 galculator yelp init udftools haveged f3 nwipe \
-hexedit gvfs pm-utils \
+hexedit gvfs pm-utils arch-install-scripts \
 $debian_pkgs_for_gparted $Xorg_pkgs $font_pkgs"
 categories_default="main contrib"
 cpu_flavor_default="amd64"


### PR DESCRIPTION
nvme-cli provides command to operate nvme disks such as getting logs and formatting.

arch-install-scripts provides handy commands to deal with chroot environment such as genfstab and arch-chroot.